### PR TITLE
Mulighed for at hente oplysninger fra en datasource til at udfylde en dropdown

### DIFF
--- a/js/formular.js
+++ b/js/formular.js
@@ -291,9 +291,22 @@ Formular = SpatialMap.Class ({
 	                                if (type=='dropdown') {
 	                                    jQuery('#content'+k+' > tbody:last').append('<tr id="'+id+'_row"><td><div class="labeldiv'+(className ? ' '+className : '')+'" id="'+id+'_displayname">'+node.attr('displayname')+'<div></td><td><div class="valuediv"><select class="select1" id="'+id+'"/></div></td></tr>');
 	                                    var option = node.find('option');
-	                                    for (var j=0;j<option.length;j++) {
-	                                    	var checked = (jQuery(option[j]).attr('value') == value ? ' selected="selected"' : '');
-	                                        $('#'+id).append('<option value="'+jQuery(option[j]).attr('value')+'"'+checked+'>'+jQuery(option[j]).attr('name')+'</option>');
+	                                    var list = [];
+	                                    if (node.attr('datasource')) {
+	                                    	list = this.dropdownFromDatasource(node.attr('datasource'));
+	                                    } else {
+		                                    for (var j=0;j<option.length;j++) {
+		                                    	list.push({
+		                                    		value: jQuery(option[j]).attr('value'),
+		                                    		name: jQuery(option[j]).attr('name'),
+		                                    		checked: jQuery(option[j]).attr('value') == value
+		                                    	});
+		                                    }
+	                                    }
+	                                    
+	                                    for (var j=0;j<list.length;j++) {
+	                                    	var checked = (list[j].checked ? ' selected="selected"' : '');
+	                                        $('#'+id).append('<option value="'+list[j].value+'"'+checked+'>'+list[j].name+'</option>');
 	                                    }
 	                                } else if (type=='radiobutton') {
 	                                    var option = node.find('option');
@@ -645,6 +658,33 @@ Formular = SpatialMap.Class ({
                 }
             },this)
         });
+    },
+    
+    dropdownFromDatasource: function (datasource) {
+        var params = {
+            page: 'formular.read.dropdown',
+            sessionid: this.sessionid,
+            datasource: datasource
+        };
+        var list = [];
+        jQuery.ajax( {
+            url: 'cbkort',
+            dataType: 'xml',
+            type: 'POST',
+            async: false,
+            data: params,
+            success : function(data, status) {
+            	var rows = jQuery(data).find('row');
+            	for (var i=0;i<rows.length;i++) {
+                	list.push({
+                		value: jQuery(rows[i]).find('col[name="value"]').text(),
+                		name: jQuery(rows[i]).find('col[name="name"]').text(),
+                		selected: (i==0)
+                	});
+            	}
+            }
+        });
+        return list;
     },
     
     query: function (wkt) {

--- a/pages/pages-includes.xml
+++ b/pages/pages-includes.xml
@@ -94,5 +94,12 @@
         </data>
     </page>
 
+    <page name="formular.read.dropdown" contenttype="text/xml">
+        <data handler="datasource" operation="execute-command">
+           <url-parameters>
+                <url-parameter name="command" value="read-dropdown"/>
+            </url-parameters>
+        </data>
+    </page>
 
 </pages>

--- a/test/config/formular_config.xml
+++ b/test/config/formular_config.xml
@@ -1,10 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
+    <formular name="dropdown">
+        <header>Dropdown hentet fra en datasource</header>
+        <submitpage>formular.send.general.nomap</submitpage>
+        <content>
+            <input type="hidden" urlparam="about" defaultvalue="Dropdown hentet fra en datasource"/>
+            <input type="input" displayname="Navn:" urlparam="name" defaultvalue=""/>
+            <input id="udnyttelse" type="dropdown" displayname="Arealets udnyttelse pt.:" urlparam="val0" datasource="formular-test"/>
+            <input id="kategori" type="dropdown" displayname="Kategori:" urlparam="val1">
+                <option value="1" name="Bygninger"/>
+                <option value="2" name="Veje &amp; stier"/>
+                <option value="3" name="Grønne områder"/>
+            </input>
+        </content>
+    </formular>
     <formular name="distance">
         <header>Beregning af afstand i kategorier</header>
         <submitpage>formular.send.general.nomap</submitpage>
         <content>
             <input type="hidden" urlparam="about" defaultvalue="Beregning af afstande"/>
+            <input type="input" displayname="Navn:" urlparam="name" defaultvalue=""/>
             <address id="addressa" urlparam="val0" displayname="Fra Adresse:" apikey="[module.spatialaddress.apikey]" filter="komnr0101" disablemap="true" geometry_selected="calculateDistance('addressa','addressb')"></address>
             <address id="addressb" urlparam="val1" displayname="Til Adresse:" apikey="[module.spatialaddress.apikey]" filter="komnr0101" disablemap="true" geometry_selected="calculateDistance('addressa','addressb')"></address>
             <input id="distance" type="text" displayname="Afstand (fugleflugt): " displayresult="0 m" urlparam="val2" onchange="var d = jQuery(this).val();if (d>5000) {jQuery('#zone').html('Zone 5')} else {jQuery('#zone').html('Zone 1')}"/>

--- a/test/datasources/datasources.xml
+++ b/test/datasources/datasources.xml
@@ -51,6 +51,8 @@
         <sql command="booking-approve">UPDATE formulartest SET approved = 1, updated = [timestamp: SystemTime()] where ID = [string: id]</sql>
         <sql command="booking-decline">UPDATE formulartest SET approved = -1, updated = [timestamp: SystemTime()] where ID = [string: id]</sql>
 
+        <sql command="read-dropdown">select '' || name as value, name from formulartest where name &lt;&gt; ''</sql>
+
         <debug>false</debug>
     </datasource>
 


### PR DESCRIPTION
Tilføj en "datasource" atribut til input elementet.
Datasourcen skal have en command, der hedder "read-dropdown".
Command'en er hårdkodet for at begrænse adgangen lidt.
Command'en skal returnere to colonner, der skal hedde hhv. "value" og "name".

closes #45
