### PR TITLE
Bedring håndtering af multiple geometrier og antal dage

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ I filen er der angivet én eller flere formular konfigurationer. Hver konfigurat
             <map>
                 <!-- Følgende atributter kan tilføjes til et map:
                     multiplegeometries  - Default false. Skal man kunne tegne flere geometrier i kortet
+					mergegeometries		- Default true. Sættes den til false, vil de multiple geometrier IKKE blive samlet (merged) til en multigeometi i forbindelse med lagring i databasen
                     onchange            - Hvis man gerne vil have at der sker noget afhængigt af hvilket udsnit man ser eller hvilket zoomlevel man er i. 
 					featurechange		- Man kan kalde en javascript funktion, hver gang der sker en ændring i geometrierne i kortet
                 -->

--- a/js/formular.js
+++ b/js/formular.js
@@ -805,7 +805,7 @@ Formular = SpatialMap.Class ({
                 }
                 
                 this.multipleGeometries = (typeof node.attr('multiplegeometries') !== 'undefined' && node.attr('multiplegeometries') === 'true');
-                this.mergeGeometries = (typeof node.attr('mergegeometries') !== 'undefined' && node.attr('mergegeometries') === 'false');
+                this.mergeGeometries = (typeof node.attr('mergegeometries') === 'undefined' || node.attr('mergegeometries') === 'true');
 				
 				if (this.multipleGeometries === true) {
 					this.style.label = '';
@@ -3024,6 +3024,9 @@ Formular = SpatialMap.Class ({
             
             for (var i=0;i<this.feature.length;i++) {
                 var p = this.getParams(this.feature[i].params, params);
+				if (!this.mergeGeometries) {
+					p.params.wkt = this.feature[i].wkt.toString();
+				}
                 
                 jQuery.ajax( {
                     url : 'cbkort',
@@ -3354,7 +3357,7 @@ Formular = SpatialMap.Class ({
             date2 = date2.split('.');
             date2 = new Date(date2[2],date2[1]-1,date2[0]);
             
-            count = (date2-date1)/1000/60/60/24;
+            count = Math.round((date2-date1)/1000/60/60/24);
             if (typeof nrOfAddedDays === 'number') {
                 count += nrOfAddedDays;
             }


### PR DESCRIPTION
I forbindelse med multiple geometrier blev disse tidligere samlet
(merged) inden de blev lagret. Derved fik man N ens multigeomtier med
forskellige attributter. Dette håndteres nu via mergegeomtries tag´et på
map elementet.
'Antal dage'-beregneren kom frem til kommatal ved forskellige dato
intervaller (eks: 22.03.2016 og 20.05.2016 gav 68.9583 dage). Derfor er
der sat afrunding på resultatet