### PR TITLE
Håndtering af maksimal filstørrelse i forbindelse med upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.settings
 .DS_Store
 *.db
+js/formular - Copy.js

--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ I filen er der angivet én eller flere formular konfigurationer. Hver konfigurat
 
             <!-- input - type="file" -->
             <!-- Felt til at vedhæfte en fil -->
-            <input type="file" displayname="Vedhæft tegning:" urlparam="filnavn"/>
+			<!-- maxfilesize angiver i Mb, hvor stor filen maksimalt må være --> 
+            <input type="file" displayname="Vedhæft tegning:" urlparam="filnavn" maxfilesize="5"/>
 
             <!-- input - type="checkbox" -->
             <!-- En check boks hvor brugeren kan vælge til eller fra. Serveren modtager "true", hvis brugeren har valgt at klikke den til, ellers sendes "false".

--- a/js/formular.js
+++ b/js/formular.js
@@ -3848,8 +3848,15 @@ Formular = SpatialMap.Class ({
                 }
             }
         }
-    }
+    },
 
+    paramHasValue: function (param) {
+        var curParam = this.currentParams[param];
+        if (typeof curParam !== 'undefined' && curParam != null && curParam.length > 0) {
+            return true;
+        }
+        return false;
+    }
 });
 
 

--- a/js/formular.js
+++ b/js/formular.js
@@ -91,6 +91,7 @@ Formular = SpatialMap.Class ({
 	groupedLayers: [],
     
     _listeners: [],
+    maxUploadFileSize: 100,
     
     initialize: function (options) {
         SpatialMap.Util.extend (this, options);
@@ -1390,11 +1391,12 @@ Formular = SpatialMap.Class ({
                     jQuery('#'+id).datepicker(options);
                     
                 } else if (type=='file') {
+                    this.maxUploadFileSize = typeof node.attr('maxfilesize') === 'undefined' ? 100 : parseInt(node.attr('maxfilesize'));
                     if (this.bootstrap === true) {
-                        contentcontainer.append('<div id="'+id+'_row" class="form-group'+(className ? ' '+className : '')+'"><label for="'+id+'">'+node.attr('displayname')+(req ? ' <span class="required">*</span>':'')+'</label><input type="hidden" id="'+id+'" value="'+(value || '')+'"/><input type="hidden" id="'+id+'_org" value="'+(value || '')+'"/><div class="fileupload'+(req ? ' required-enabled':'')+'"><form id="form_'+id+'" method="POST" target="uploadframe_'+id+'" enctype="multipart/form-data" action="/jsp/modules/formular/upload.jsp"><input '+(postparam.disabled ? 'disabled':'')+' type="file" name="file_'+id+'" id="file_'+id+'" /><span class="filupload-delete" title="Fjern vedhæftet fil"></span><input type="hidden" name="callbackhandler" value="parent.formular.fileupload"/><input type="hidden" name="id" value="'+id+'"/><input type="hidden" name="sessionid" value="'+this.sessionid+'"/><input type="hidden" name="formular" value="'+this.name+'"/></form><iframe name="uploadframe_'+id+'" id="uploadframe_'+id+'" frameborder="0" style="display:none;"></iframe></div></div>');
+                        contentcontainer.append('<div id="'+id+'_row" class="form-group'+(className ? ' '+className : '')+'"><label for="'+id+'">'+node.attr('displayname')+(req ? ' <span class="required">*</span>':'')+'</label><input type="hidden" id="'+id+'" value="'+(value || '')+'"/><input type="hidden" id="'+id+'_org" value="'+(value || '')+'"/><div class="fileupload'+(req ? ' required-enabled':'')+'"><form id="form_'+id+'" method="POST" target="uploadframe_'+id+'" enctype="multipart/form-data" action="/jsp/modules/formular/upload.jsp"><input '+(postparam.disabled ? 'disabled':'')+' type="file" name="file_'+id+'" id="file_'+id+'" /><span class="filupload-delete" title="Fjern vedhæftet fil"></span><input type="hidden" name="callbackhandler" value="parent.formular.fileupload"/><input type="hidden" name="id" value="'+id+'"/><input type="hidden" name="sessionid" value="'+this.sessionid+'"/><input type="hidden" name="formular" value="'+this.name+'"/> <input type="hidden" name="maxfilesize" value="'+this.maxUploadFileSize+'"/> </form><iframe name="uploadframe_'+id+'" id="uploadframe_'+id+'" frameborder="0" style="display:none;"></iframe></div></div>');
                         contentcontainer.find('#'+id+'_row .filupload-delete').click(SpatialMap.Function.bind(this.deleteFileUpload,this,id)).hide();
                     } else {
-                        contentcontainer.append('<tr id="'+id+'_row"><td><input type="hidden" id="'+id+'" value="'+(value || '')+'"/><input type="hidden" id="'+id+'_org" value="'+(value || '')+'"/><div class="labeldiv'+(className ? ' '+className : '')+'" id="'+id+'_displayname">'+node.attr('displayname')+'</div></td><td><div class="valuediv"><form id="form_'+id+'" method="POST" target="uploadframe_'+id+'" enctype="multipart/form-data" action="/jsp/modules/formular/upload.jsp"><input type="file" name="file_'+id+'" id="file_'+id+'" /><input type="hidden" name="callbackhandler" value="parent.formular.fileupload"/><input type="hidden" name="id" value="'+id+'"/><input type="hidden" name="sessionid" value="'+this.sessionid+'"/><input type="hidden" name="formular" value="'+this.name+'"/></form><iframe name="uploadframe_'+id+'" id="uploadframe_'+id+'" frameborder="0" style="display:none;"></iframe></div></td></tr>');
+                        contentcontainer.append('<tr id="'+id+'_row"><td><input type="hidden" id="'+id+'" value="'+(value || '')+'"/><input type="hidden" id="'+id+'_org" value="'+(value || '')+'"/><div class="labeldiv'+(className ? ' '+className : '')+'" id="'+id+'_displayname">'+node.attr('displayname')+'</div></td><td><div class="valuediv"><form id="form_'+id+'" method="POST" target="uploadframe_'+id+'" enctype="multipart/form-data" action="/jsp/modules/formular/upload.jsp"><input type="file" name="file_'+id+'" id="file_'+id+'" /><input type="hidden" name="callbackhandler" value="parent.formular.fileupload"/><input type="hidden" name="id" value="'+id+'"/><input type="hidden" name="sessionid" value="'+this.sessionid+'"/><input type="hidden" name="formular" value="'+this.name+'"/> <input type="hidden" name="maxfilesize" value="'+this.maxUploadFileSize+'"/> </form><iframe name="uploadframe_'+id+'" id="uploadframe_'+id+'" frameborder="0" style="display:none;"></iframe></div></td></tr>');
                     }
                     jQuery('#file_'+id).change (SpatialMap.Function.bind(function (id) {
                         this.startFileUpload(id);
@@ -3601,11 +3603,30 @@ Formular = SpatialMap.Class ({
         jQuery('#'+id+'_row .filupload-delete').hide();
     },
 
-    fileupload: function (filename,id,orgfilename) {
+    removeInvalidFileNotice: function (id) {
+        var invalidFileDiv = jQuery('#'+id+'_invalidfile');
+        if (invalidFileDiv.length > 0) {
+            invalidFileDiv.remove();
+        }
+    },
+
+    fileupload: function (filename,id,orgfilename,filesize) {
         this.endFileUpload();
-        jQuery('#'+id).val(filename);
-        jQuery('#'+id+'_org').val(orgfilename);
-        jQuery('#'+id+'_row .filupload-delete').show();
+        this.removeInvalidFileNotice(id);
+        if (typeof filesize !== 'undefined' && (parseInt(filesize) <= this.maxUploadFileSize)) {
+            jQuery('#'+id).val(filename);
+            jQuery('#'+id+'_org').val(orgfilename);
+            jQuery('#'+id+'_row .filupload-delete').show();
+        } else {
+            this.deleteFileUpload(id);
+            var inputRow = jQuery('#'+id+'_row');
+            var destinationTd = inputRow.children()[1];
+            jQuery('<div/>', {
+                id: id+'_invalidfile',
+                text: 'Filen overskride den maksimale størrelse!'
+            }).appendTo(destinationTd)
+
+        }
     },
     
     start: function (options) {

--- a/jsp/upload.jsp
+++ b/jsp/upload.jsp
@@ -30,6 +30,8 @@
     String callbackID = "";
     String formular = "formular";
     String orgFileName = "";
+	double fileSize = -1;
+	int maxFileSize = 0;
     FileItem fileUpload = null;
     request.setCharacterEncoding("UTF-8");
     ServletRequestContext src = new ServletRequestContext(request);
@@ -80,21 +82,29 @@
              sessionID = value;
          if (name.equalsIgnoreCase("formular"))
              formular = value;
+         if (name.equalsIgnoreCase("maxfilesize"))
+             maxFileSize = Integer.parseInt(value);
        }
      }
    }
    
    if(fileUpload != null)
    {
-       Random rand = new Random(System.currentTimeMillis()) ;
-       long n = Math.abs(rand.nextLong() % 1000000);
-       orgFileName = uploadedFilename;
-       filename = formular+"_" + n +"_"+uploadedFilename;
-       filename = filename.replaceAll(",", "_");
-       filename = filename.replaceAll(";", "_");
-       uploadedFilename = tmpDir + File.separator + filename;
-       File uploadedFile = new File(uploadedFilename);
-       fileUpload.write(uploadedFile);
+	   //1024*1024 is the size for megbytes
+	   if (fileUpload.getSize() <= (maxFileSize *1024 *1024)) {
+		   Random rand = new Random(System.currentTimeMillis()) ;
+		   long n = Math.abs(rand.nextLong() % 1000000);
+		   orgFileName = uploadedFilename;
+		   filename = formular+"_" + n +"_"+uploadedFilename;
+		   filename = filename.replaceAll(",", "_");
+		   filename = filename.replaceAll(";", "_");
+		   uploadedFilename = tmpDir + File.separator + filename;
+		   File uploadedFile = new File(uploadedFilename);
+		   fileUpload.write(uploadedFile);
+		   fileSize = uploadedFile.length()/(1024*1024); 
+	   } else {
+		   fileSize = fileUpload.getSize();
+	   }
    }
 
    if (callbackID == null)
@@ -102,7 +112,7 @@
    if (callbackHandler == null)
          callbackHandler = "parent.uploadFilename";
 
-   out.println("<body onload=\"" + callbackHandler + "('" + filename.replace('\\', '/') + "','"+callbackID+"','"+orgFileName+"');\">");
+   out.println("<body onload=\"" + callbackHandler + "('" + filename.replace('\\', '/') + "','"+callbackID+"','"+orgFileName+"','" + fileSize + "');\">");
 //    out.println("Fil uploadet og skrevet til: " + uploadedFilename);
    out.println("</body>");
 %>


### PR DESCRIPTION
Det kan være praktisk at kunne styre, hvor store filer der må uploades via en formular. Følgende rettelser til henholdsvis upload.jsp og formular.js (med dokumentation i readme.md) gør det muligt, at sætte en attribut (maxfilsize="&lt;Mb som heltal&gt;") på file tag´et i en formular.

Da jeg lokalt havde merged koden i relation til (Håndtering af parametre i forbindelse med NemLogin #160) sammen med denne rettelse/opdatering er det muligt at #160 blot skal ignoreres - ellers kommer funktionen paramHasValue muligvis ind 2 gange.